### PR TITLE
Escape execution of mill command

### DIFF
--- a/millw.bat
+++ b/millw.bat
@@ -80,4 +80,4 @@ if not exist "%MILL%" (
 set MILL_DOWNLOAD_PATH=
 set MILL_VERSION=
 
-%MILL% %*
+"%MILL%" %*


### PR DESCRIPTION
Fixes issues like https://github.com/scalameta/metals/issues/1600 where there may be a space in the path to the mill command.