### PR TITLE
Support running millw under Git Bash on Windows

### DIFF
--- a/millw
+++ b/millw
@@ -77,7 +77,7 @@ fi
 MILL="${MILL_DOWNLOAD_PATH}/${MILL_VERSION}"
 
 # If not already downloaded, download it
-if [ ! -x "${MILL}" ] ; then
+if [ ! -s "${MILL}" ] ; then
   
   # support old non-XDG download dir
   MILL_OLD_DOWNLOAD_PATH="${HOME}/.mill/download"


### PR DESCRIPTION
The issue is, that running "chmod +x" does not result in an executable mill binary, but it works nevertheless, so instead of checking for an executable file, we just look for an ordinary non-empty file.