### PR TITLE
Use curl for downloading Mill instead of bitsadmin, if curl is present

### DIFF
--- a/millw
+++ b/millw
@@ -11,7 +11,7 @@
 # Licensed under the Apache License, Version 2.0
 
 
-DEFAULT_MILL_VERSION=0.5.0
+DEFAULT_MILL_VERSION=0.9.5
 
 set -e
 

--- a/millw.bat
+++ b/millw.bat
@@ -14,7 +14,7 @@ rem setlocal seems to be unavailable on Windows 95/98/ME
 rem but I don't think we need to support them in 2019
 setlocal enabledelayedexpansion
 
-set "DEFAULT_MILL_VERSION=0.5.0"
+set "DEFAULT_MILL_VERSION=0.9.5"
 
 rem %~1% removes surrounding quotes
 if [%~1%]==[--mill-version] (

--- a/millw.bat
+++ b/millw.bat
@@ -73,7 +73,7 @@ if not exist "%MILL%" (
     bitsadmin /transfer millDownloadJob /dynamic /priority foreground "https://github.com/lihaoyi/mill/releases/download/!MILL_BASE_VERSION!/!MILL_VERSION!!DOWNLOAD_SUFFIX!" "!DOWNLOAD_FILE!"
     if not exist "!DOWNLOAD_FILE!" (
         echo Could not download mill %MILL_VERSION%
-        exit 1
+        exit /b 1
     )
 
     move /y "!DOWNLOAD_FILE!" "%MILL%"

--- a/millw.bat
+++ b/millw.bat
@@ -62,15 +62,22 @@ if not exist "%MILL%" (
     rem there seems to be no way to generate a unique temporary file path (on native Windows)
     set DOWNLOAD_FILE=%MILL%.tmp
 
+    set DOWNLOAD_URL=https://github.com/lihaoyi/mill/releases/download/!MILL_BASE_VERSION!/!MILL_VERSION!!DOWNLOAD_SUFFIX!
+
     echo Downloading mill %MILL_VERSION% from https://github.com/lihaoyi/mill/releases ...
 
+    if not exist "%MILL_DOWNLOAD_PATH%" mkdir "%MILL_DOWNLOAD_PATH%"
     rem curl is bundled with recent Windows 10
     rem but I don't think we can expect all the users to have it in 2019
-    rem bitadmin seems to be available on Windows 7
-    rem without /dynamic, github returns 403
-    rem bitadmin is sometimes needlessly slow but it looks better with /priority foreground
-    if not exist "%MILL_DOWNLOAD_PATH%" mkdir "%MILL_DOWNLOAD_PATH%"
-    bitsadmin /transfer millDownloadJob /dynamic /priority foreground "https://github.com/lihaoyi/mill/releases/download/!MILL_BASE_VERSION!/!MILL_VERSION!!DOWNLOAD_SUFFIX!" "!DOWNLOAD_FILE!"
+    where /Q curl
+    if %ERRORLEVEL% EQU 0 (
+        curl -L "!DOWNLOAD_URL!" -o "!DOWNLOAD_FILE!"
+    ) else (
+        rem bitsadmin seems to be available on Windows 7
+        rem without /dynamic, github returns 403
+        rem bitsadmin is sometimes needlessly slow but it looks better with /priority foreground
+        bitsadmin /transfer millDownloadJob /dynamic /priority foreground "!DOWNLOAD_URL!" "!DOWNLOAD_FILE!"
+    )
     if not exist "!DOWNLOAD_FILE!" (
         echo Could not download mill %MILL_VERSION%
         exit /b 1


### PR DESCRIPTION
I have made some improvements to the millw.bat script.
1) bitsadmin fails to download mill on my machine (Windows 10) whereas curl works fine. I changed the script to use curl, if curl is found in the path.
2) an exit command was missing a /b causing the entire command prompt to exit when bitsadmin failed downloading Mill
3) I suggest bumping the default version to the current version of Mill (0.9.5)