### PR TITLE
curl -f so invalid URLs don't create invalid files

### DIFF
--- a/millw
+++ b/millw
@@ -19,7 +19,7 @@ set -e
 MILL_REPO_URL="https://github.com/com-lihaoyi/mill"
 
 if [ "x${CURL_CMD}" = "x" ] ; then
-  CURL_CMD=curl
+  CURL_CMD=curl -f
 fi
 
 # Explicit commandline argument takes precedence over all other methods


### PR DESCRIPTION
See https://stackoverflow.com/a/13201595/333643. I've tested this behavior.

Necessary because right now returns a 404 and it's creating `~/.cache/mill/download/0.9.11` as a text file with the string `Not Found`