### PR TITLE
Fix Bashisms and obsolete stuff found by shellcheck in millw, add CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,13 @@
+name: CI
+
+on: [push, pull_request]
+
+jobs:
+  check:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install packages
+        run: sudo apt-get install -y make shellcheck 
+      - name: Check
+        run: make check

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,3 @@
+.PHONY:
+check:
+	shellcheck millw

--- a/millw
+++ b/millw
@@ -18,12 +18,12 @@ set -e
 
 MILL_REPO_URL="https://github.com/com-lihaoyi/mill"
 
-if [ "x${CURL_CMD}" = "x" ] ; then
+if [ -z "${CURL_CMD}" ] ; then
   CURL_CMD=curl
 fi
 
 # Explicit commandline argument takes precedence over all other methods
-if [ "x$1" = "x--mill-version" ] ; then
+if [ "$1" = "--mill-version" ] ; then
   shift
   if [ "x$1" != "x" ] ; then
     MILL_VERSION="$1"
@@ -40,7 +40,7 @@ fi
 # We reuse it's value and skip searching for a value.
 
 # If not already set, read .mill-version file
-if [ "x${MILL_VERSION}" = "x" ] ; then
+if [ -z "${MILL_VERSION}" ] ; then
   if [ -f ".mill-version" ] ; then
     MILL_VERSION="$(head -n 1 .mill-version 2> /dev/null)"
   fi
@@ -53,7 +53,7 @@ else
 fi
 
 # If not already set, try to fetch newest from Github
-if [ "x${MILL_VERSION}" = "x" ] ; then
+if [ -z "${MILL_VERSION}" ] ; then
   # TODO: try to load latest version from release page
   echo "No mill version specified." 1>&2
   echo "You should provide a version via '.mill-version' file or --mill-version option." 1>&2
@@ -68,20 +68,22 @@ if [ "x${MILL_VERSION}" = "x" ] ; then
     # to show the (previously suppressed) error message
     LANG=C touch -d '1 hour ago' "${MILL_DOWNLOAD_PATH}/.expire_latest"
   )
-  
-  if [ "${MILL_DOWNLOAD_PATH}/.latest" -nt "${MILL_DOWNLOAD_PATH}/.expire_latest" ] ; then
+
+  # POSIX shell variant of bash's -nt operator, see https://unix.stackexchange.com/a/449744/6993
+  # if [ "${MILL_DOWNLOAD_PATH}/.latest" -nt "${MILL_DOWNLOAD_PATH}/.expire_latest" ] ; then
+  if [ -n "$(find -L "${MILL_DOWNLOAD_PATH}/.latest" -prune -newer "${MILL_DOWNLOAD_PATH}/.expire_latest")" ]; then
     # we know a current latest version
-    MILL_VERSION="$(head -n 1 ${MILL_DOWNLOAD_PATH}/.latest 2> /dev/null)"
+    MILL_VERSION=$(head -n 1 "${MILL_DOWNLOAD_PATH}"/.latest 2> /dev/null)
   fi
 
-  if [ "x${MILL_VERSION}" = "x" ] ; then
+  if [ -z "${MILL_VERSION}" ] ; then
     # we don't know a current latest version
     echo "Retrieving latest mill version ..." 1>&2
     LANG=C ${CURL_CMD} -s -i -f -I ${MILL_REPO_URL}/releases/latest 2> /dev/null  | grep --ignore-case Location: | sed s'/^.*tag\///' | tr -d '\r\n' > "${MILL_DOWNLOAD_PATH}/.latest"
-    MILL_VERSION="$(head -n 1 ${MILL_DOWNLOAD_PATH}/.latest 2> /dev/null)"
+    MILL_VERSION=$(head -n 1 "${MILL_DOWNLOAD_PATH}"/.latest 2> /dev/null)
   fi
 
-  if [ "x${MILL_VERSION}" = "x" ] ; then
+  if [ -z "${MILL_VERSION}" ] ; then
     # Last resort
     MILL_VERSION="${DEFAULT_MILL_VERSION}"
     echo "Falling back to hardcoded mill version ${MILL_VERSION}" 1>&2
@@ -94,14 +96,14 @@ MILL="${MILL_DOWNLOAD_PATH}/${MILL_VERSION}"
 
 # If not already downloaded, download it
 if [ ! -s "${MILL}" ] ; then
-  
+
   # support old non-XDG download dir
   MILL_OLD_DOWNLOAD_PATH="${HOME}/.mill/download"
   OLD_MILL="${MILL_OLD_DOWNLOAD_PATH}/${MILL_VERSION}"
   if [ -x "${OLD_MILL}" ] ; then
     MILL="${OLD_MILL}"
   else
-    VERSION_PREFIX="$(echo -n $MILL_VERSION | cut -b -4)"
+    VERSION_PREFIX="$(echo $MILL_VERSION | cut -b -4)"
     case $VERSION_PREFIX in
       0.0. | 0.1. | 0.2. | 0.3. | 0.4. )
         DOWNLOAD_SUFFIX=""
@@ -133,4 +135,4 @@ unset MILL_VERSION
 unset MILL_VERSION_TAG
 unset MILL_REPO_URL
 
-exec $MILL "$@"
+exec "${MILL}" "$@"


### PR DESCRIPTION
Fixes the following issues found by shellcheck

$ shellcheck millw

In millw line 21:
if [ "x${CURL_CMD}" = "x" ] ; then
     ^------------^ SC2268: Avoid x-prefix in comparisons as it no longer serves a purpose.

Did you mean:
if [ "${CURL_CMD}" = "" ] ; then

In millw line 26:
if [ "x$1" = "x--mill-version" ] ; then
     ^---^ SC2268: Avoid x-prefix in comparisons as it no longer serves a purpose.

Did you mean:
if [ "$1" = "--mill-version" ] ; then

In millw line 43:
if [ "x${MILL_VERSION}" = "x" ] ; then
     ^----------------^ SC2268: Avoid x-prefix in comparisons as it no longer serves a purpose.

Did you mean:
if [ "${MILL_VERSION}" = "" ] ; then

In millw line 56:
if [ "x${MILL_VERSION}" = "x" ] ; then
     ^----------------^ SC2268: Avoid x-prefix in comparisons as it no longer serves a purpose.

Did you mean:
if [ "${MILL_VERSION}" = "" ] ; then

In millw line 72:
  if [ "${MILL_DOWNLOAD_PATH}/.latest" -nt "${MILL_DOWNLOAD_PATH}/.expire_latest" ] ; then
                                       ^-^ SC3013: In POSIX sh, -nt is undefined.

In millw line 74:
    MILL_VERSION="$(head -n 1 ${MILL_DOWNLOAD_PATH}/.latest 2> /dev/null)"
                              ^-------------------^ SC2086: Double quote to prevent globbing and word splitting.

Did you mean:
    MILL_VERSION="$(head -n 1 "${MILL_DOWNLOAD_PATH}"/.latest 2> /dev/null)"

In millw line 77:
  if [ "x${MILL_VERSION}" = "x" ] ; then
       ^----------------^ SC2268: Avoid x-prefix in comparisons as it no longer serves a purpose.

Did you mean:
  if [ "${MILL_VERSION}" = "" ] ; then

In millw line 81:
    MILL_VERSION="$(head -n 1 ${MILL_DOWNLOAD_PATH}/.latest 2> /dev/null)"
                              ^-------------------^ SC2086: Double quote to prevent globbing and word splitting.

Did you mean:
    MILL_VERSION="$(head -n 1 "${MILL_DOWNLOAD_PATH}"/.latest 2> /dev/null)"

In millw line 84:
  if [ "x${MILL_VERSION}" = "x" ] ; then
       ^----------------^ SC2268: Avoid x-prefix in comparisons as it no longer serves a purpose.

Did you mean:
  if [ "${MILL_VERSION}" = "" ] ; then

In millw line 104:
    VERSION_PREFIX="$(echo -n $MILL_VERSION | cut -b -4)"
                           ^-- SC3037: In POSIX sh, echo flags are undefined.

For more information:
  https://www.shellcheck.net/wiki/SC3013 -- In POSIX sh, -nt is undefined.
  https://www.shellcheck.net/wiki/SC3037 -- In POSIX sh, echo flags are undef...
  https://www.shellcheck.net/wiki/SC2086 -- Double quote to prevent globbing ...