### PR TITLE
Fix missing mill in PATH

### DIFF
--- a/millw
+++ b/millw
@@ -95,7 +95,7 @@ fi
 MILL="${MILL_DOWNLOAD_PATH}/${MILL_VERSION}"
 
 try_to_use_system_mill() {
-  MILL_IN_PATH=$(command -v mill)
+  MILL_IN_PATH=$(command -v mill || true)
 
   if [ -z "${MILL_IN_PATH}" ]; then
     return

--- a/millw
+++ b/millw
@@ -95,7 +95,7 @@ fi
 MILL="${MILL_DOWNLOAD_PATH}/${MILL_VERSION}"
 
 try_to_use_system_mill() {
-  MILL_IN_PATH=$(command -v mill || true)
+  MILL_IN_PATH="$(command -v mill || true)"
 
   if [ -z "${MILL_IN_PATH}" ]; then
     return


### PR DESCRIPTION
Seems `MILL_IN_PATH=$(command -v mill)` makes `millw` fail when `mill` is not in `PATH`. This fixes that.