### PR TITLE
Improve remaining "variable non-empty" check

### DIFF
--- a/millw
+++ b/millw
@@ -46,7 +46,7 @@ if [ -z "${MILL_VERSION}" ] ; then
   fi
 fi
 
-if [ "x${XDG_CACHE_HOME}" != "x" ] ; then
+if [ -n "${XDG_CACHE_HOME}" ] ; then
   MILL_DOWNLOAD_PATH="${XDG_CACHE_HOME}/mill/download"
 else
   MILL_DOWNLOAD_PATH="${HOME}/.cache/mill/download"


### PR DESCRIPTION
Most of these where already improved by 14a445cd0889 ("Fix Bashisms
and obsolete stuff found by shellcheck in millw, add CI (#31)").