### PR TITLE
Fallback to an DEFAULT_MILL_VERSION environment variable, if present

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -27,7 +27,7 @@ sh $ mill --mill-version {mill-version} --disable-ticker version
 {mill-version}
 ----
 
-* else if the environment variable `MILL_VERSION` is defined, it's value will be used.
+* If the environment variable `MILL_VERSION` is defined, it's value will be used.
 +
 .Example
 [source,sh,subs="attributes,verbatim"]
@@ -36,7 +36,7 @@ sh $ MILL_VERSION mill --disable-ticker version
 {mill-version}
 ----
 
-* else if there is a file `.mill-version` in the working directory, it's content will be used as mill version.
+* If there is a file `.mill-version` in the working directory, it's content will be used as mill version.
   The file must have only a mill version as content, no additional content or comments are supported.
 +
 .Example
@@ -48,9 +48,11 @@ sh $ mill --disable-ticker version
 {mill-version}
 ----
 
-* else if there is a file `.config/mill-version`, it's content will be used as mill version.
+* If there is a file `.config/mill-version`, it's content will be used as mill version.
 
 * The latest mill release available from the Github release pages will be used.
+
+* If the environment variable `DEFAULT_MILL_VERSION` is set, its value will be used.
 
 * The values of the `DEFAULT_MILL_VERSION` variable inside the script will be used.
 

--- a/README.adoc
+++ b/README.adoc
@@ -27,7 +27,7 @@ sh $ mill --mill-version {mill-version} --disable-ticker version
 {mill-version}
 ----
 
-* If the environment variable `MILL_VERSION` is defined, it's value will be used.
+* If the environment variable `MILL_VERSION` is defined, its value will be used.
 +
 .Example
 [source,sh,subs="attributes,verbatim"]
@@ -36,7 +36,7 @@ sh $ MILL_VERSION mill --disable-ticker version
 {mill-version}
 ----
 
-* If there is a file `.mill-version` in the working directory, it's content will be used as mill version.
+* If there is a file `.mill-version` in the working directory, its content will be used as mill version.
   The file must have only a mill version as content, no additional content or comments are supported.
 +
 .Example
@@ -48,7 +48,7 @@ sh $ mill --disable-ticker version
 {mill-version}
 ----
 
-* If there is a file `.config/mill-version`, it's content will be used as mill version.
+* If there is a file `.config/mill-version`, its content will be used as mill version.
 
 * The latest mill release available from the Github release pages will be used.
 

--- a/millw
+++ b/millw
@@ -11,10 +11,12 @@
 #
 # Licensed under the Apache License, Version 2.0
 
-
-DEFAULT_MILL_VERSION=0.10.0
-
 set -e
+
+if [ -z "${DEFAULT_MILL_VERSION}" ] ; then
+  DEFAULT_MILL_VERSION=0.10.7
+fi
+
 
 MILL_REPO_URL="https://github.com/com-lihaoyi/mill"
 

--- a/millw.bat
+++ b/millw.bat
@@ -15,7 +15,9 @@ rem setlocal seems to be unavailable on Windows 95/98/ME
 rem but I don't think we need to support them in 2019
 setlocal enabledelayedexpansion
 
-set "DEFAULT_MILL_VERSION=0.10.0"
+if [!DEFAULT_MILL_VERSION!]==[] (
+    set "DEFAULT_MILL_VERSION=0.10.0"
+)
 
 set "MILL_REPO_URL=https://github.com/com-lihaoyi/mill"
 


### PR DESCRIPTION
So you can use your preferred Mill version in projects, where no local settings exist.
