### PR TITLE
Add support for GitHub release CDN

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -94,6 +94,11 @@ def millw() = T.command {
 }
 ----
 
+== GitHub release CDN support
+
+In some areas, the network environment makes downloading files from GitHub release very time-consuming. Fortunately,
+some CDN services can speed up GitHub release files. You can use the `GITHUB_RELEASE_CDN` environment variable to add
+a CDN url prefix before the original GitHub release file url to speed up your file downloads!
 
 == License
 

--- a/millw
+++ b/millw
@@ -18,6 +18,11 @@ if [ -z "${DEFAULT_MILL_VERSION}" ] ; then
 fi
 
 
+if [ -z "${GITHUB_RELEASE_CDN}" ] ; then
+  GITHUB_RELEASE_CDN=""
+fi
+
+
 MILL_REPO_URL="https://github.com/com-lihaoyi/mill"
 
 if [ -z "${CURL_CMD}" ] ; then
@@ -152,10 +157,11 @@ if [ ! -s "${MILL}" ] ; then
     unset VERSION_PREFIX
 
     DOWNLOAD_FILE=$(mktemp mill.XXXXXX)
-    # TODO: handle command not found
-    echo "Downloading mill ${MILL_VERSION} from ${MILL_REPO_URL}/releases ..." 1>&2
     MILL_VERSION_TAG=$(echo $MILL_VERSION | sed -E 's/([^-]+)(-M[0-9]+)?(-.*)?/\1\2/')
-    ${CURL_CMD} -f -L -o "${DOWNLOAD_FILE}" "${MILL_REPO_URL}/releases/download/${MILL_VERSION_TAG}/${MILL_VERSION}${DOWNLOAD_SUFFIX}"
+    DOWNLOAD_URL="${GITHUB_RELEASE_CDN}${MILL_REPO_URL}/releases/download/${MILL_VERSION_TAG}/${MILL_VERSION}${DOWNLOAD_SUFFIX}"
+    # TODO: handle command not found
+    echo "Downloading mill ${MILL_VERSION} from ${DOWNLOAD_URL} ..." 1>&2
+    ${CURL_CMD} -f -L -o "${DOWNLOAD_FILE}" ${DOWNLOAD_URL}
     chmod +x "${DOWNLOAD_FILE}"
     mkdir -p "${MILL_DOWNLOAD_PATH}"
     mv "${DOWNLOAD_FILE}" "${MILL}"

--- a/millw
+++ b/millw
@@ -161,7 +161,7 @@ if [ ! -s "${MILL}" ] ; then
     DOWNLOAD_URL="${GITHUB_RELEASE_CDN}${MILL_REPO_URL}/releases/download/${MILL_VERSION_TAG}/${MILL_VERSION}${DOWNLOAD_SUFFIX}"
     # TODO: handle command not found
     echo "Downloading mill ${MILL_VERSION} from ${DOWNLOAD_URL} ..." 1>&2
-    ${CURL_CMD} -f -L -o "${DOWNLOAD_FILE}" ${DOWNLOAD_URL}
+    ${CURL_CMD} -f -L -o "${DOWNLOAD_FILE}" "${DOWNLOAD_URL}"
     chmod +x "${DOWNLOAD_FILE}"
     mkdir -p "${MILL_DOWNLOAD_PATH}"
     mv "${DOWNLOAD_FILE}" "${MILL}"

--- a/millw.bat
+++ b/millw.bat
@@ -19,6 +19,10 @@ if [!DEFAULT_MILL_VERSION!]==[] (
     set "DEFAULT_MILL_VERSION=0.10.10"
 )
 
+if [!GITHUB_RELEASE_CDN!]==[] (
+    set "GITHUB_RELEASE_CDN="
+)
+
 set "MILL_REPO_URL=https://github.com/com-lihaoyi/mill"
 
 rem %~1% removes surrounding quotes
@@ -82,9 +86,9 @@ if not exist "%MILL%" (
     rem there seems to be no way to generate a unique temporary file path (on native Windows)
     set DOWNLOAD_FILE=%MILL%.tmp
 
-    set DOWNLOAD_URL=%MILL_REPO_URL%/releases/download/!MILL_VERSION_TAG!/!MILL_VERSION!!DOWNLOAD_SUFFIX!
+    set DOWNLOAD_URL=!GITHUB_RELEASE_CDN!%MILL_REPO_URL%/releases/download/!MILL_VERSION_TAG!/!MILL_VERSION!!DOWNLOAD_SUFFIX!
 
-    echo Downloading mill %MILL_VERSION% from %MILL_REPO_URL%/releases ... 1>&2
+    echo Downloading mill %MILL_VERSION% from !DOWNLOAD_URL! ... 1>&2
 
     if not exist "%MILL_DOWNLOAD_PATH%" mkdir "%MILL_DOWNLOAD_PATH%"
     rem curl is bundled with recent Windows 10


### PR DESCRIPTION
In some areas, the network environment makes downloading files from GitHub release very time-consuming. Fortunately,
some CDN services can speed up GitHub release files. You can use the `GITHUB_RELEASE_CDN` environment variable to add
a CDN url prefix before the original GitHub release file url to speed up your file downloads!