### PR TITLE
Add install instructions to README

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -6,6 +6,16 @@
 
 Small script to automatically fetch and execute {mill-url}[mill build tool].
 
+== Installation
+
+On any platform, you can download the the `millw` (Mac / Linux) or `millw.bat` (Windows) script files found in this repo, into the root of your project. You can then use the script file as a drop-in replacement for Mill.
+
+For convenience on Mac and Linux, use your terminal to navigate to the root of your project, then run the following command substituting in the tag of the version you wish to use (see changelog below):
+
+---
+sh $ curl -L https://raw.githubusercontent.com/lefou/millw/0.4.8/millw > mill && chmod +x mill
+---
+
 == How it works
 
 `millw` is a small wrapper script around mill and works almost identical to mill.

--- a/README.adoc
+++ b/README.adoc
@@ -12,9 +12,11 @@ On any platform, you can download the the `millw` (Mac / Linux) or `millw.bat` (
 
 For convenience on Mac and Linux, use your terminal to navigate to the root of your project, then run the following command substituting in the tag of the version you wish to use (see changelog below):
 
----
+.Example
+[source,sh,subs="attributes,verbatim"]
+----
 sh $ curl -L https://raw.githubusercontent.com/lefou/millw/0.4.8/millw > mill && chmod +x mill
----
+----
 
 == How it works
 

--- a/README.adoc
+++ b/README.adoc
@@ -1,4 +1,5 @@
 = Mill Wrapper Script
+:version: 0.4.8
 :example-mill-version: 0.11.1
 :mill-url: https://github.com/com-lihaoyi/mill
 :toc:
@@ -6,17 +7,20 @@
 
 Small script to automatically fetch and execute {mill-url}[mill build tool].
 
+
 == Installation
 
-On any platform, you can download the the `millw` (Mac / Linux) or `millw.bat` (Windows) script files found in this repo, into the root of your project. You can then use the script file as a drop-in replacement for Mill.
+On any platform, you can download the the `millw` (Mac / Linux) or `millw.bat` (Windows) script files found in this repo, into the root of your project. 
+You can then use the script file as a drop-in replacement for Mill.
 
-For convenience on Mac and Linux, use your terminal to navigate to the root of your project, then run the following command substituting in the tag of the version you wish to use (see changelog below):
+For convenience on Mac and Linux, use your terminal to navigate to the root of your project, then run the following command:
 
-.Example
+.Installing millw {version} into your project
 [source,sh,subs="attributes,verbatim"]
 ----
-sh $ curl -L https://raw.githubusercontent.com/lefou/millw/0.4.8/millw > mill && chmod +x mill
+sh $ curl -L https://raw.githubusercontent.com/lefou/millw/{version}/millw > mill && chmod +x mill
 ----
+
 
 == How it works
 


### PR DESCRIPTION
I've had to manually figure this out enough times recently that I decided it would be nice to have this in the docs for convenient reference. Feel free to re-word or reject as you see fit.