### PR TITLE
Move MILL_MAIN_CLI handling before shifting arguments

### DIFF
--- a/millw.bat
+++ b/millw.bat
@@ -23,6 +23,10 @@ if [!GITHUB_RELEASE_CDN!]==[] (
     set "GITHUB_RELEASE_CDN="
 )
 
+if [!MILL_MAIN_CLI!]==[] (
+    set "MILL_MAIN_CLI=%~f0"
+)
+
 set "MILL_REPO_URL=https://github.com/com-lihaoyi/mill"
 
 rem %~1% removes surrounding quotes
@@ -163,10 +167,6 @@ if not exist "%MILL%" (
 set MILL_DOWNLOAD_PATH=
 set MILL_VERSION=
 set MILL_REPO_URL=
-
-if [!MILL_MAIN_CLI!]==[] (
-    set "MILL_MAIN_CLI=%0"
-)
 
 rem Need to preserve the first position of those listed options
 set MILL_FIRST_ARG=


### PR DESCRIPTION
I had an [issue](https://github.com/scalameta/metals/issues/5953) with BSP import on Windows, and after some debugging I think I found the bug here.


The `MILL_MAIN_CLI` was parsed after the arguments were shifted so %0 became %2 (the version parameter)

I added additional improvement,  `%~f0` (returns absolute path),  
instead of just `%0`, which can be quirky.
https://stackoverflow.com/questions/35685721/batch-scripting-whats-the-difference-between-0-and-f0

Before:
```sh
.\.metals\millw.bat --mill-version 0.11.5 mill.bsp.BSP/install

cat .\.bsp\mill-bsp.json
{"name":"mill-bsp","argv":["0.11.5","--bsp","--disable-ticker","--color","false","--jobs","1"],"millVersion":"0.11.5","bspVersion":"2.1.0-M7","languages":["scala","java"]}
```


After:
```sh
.\.metals\millw.bat --mill-version 0.11.5 mill.bsp.BSP/install

 cat .\.bsp\mill-bsp.json
{"name":"mill-bsp","argv":["C:\\projects\\sake\\squery\\.metals\\millw.bat","--bsp","--disable-ticker","--color","false","--jobs","1"],"millVersion":"0.11.5","bspVersion":"2.1.0-M7","languages":["scala","java"]}
```