### PR TITLE
This repository needs a .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.vscode
+out
+mill.*

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
-.vscode
 out
 mill.*

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ check: shellcheck downloadcheck
 
 .PHONY: clean # Cleanup temporary output files
 clean:
-	$(RM) -rf -- "./out"
+	$(RM) -rf -- "./out" mill.*
 
 .PHONY: shellcheck # Check for issues in the shell script
 shellcheck:


### PR DESCRIPTION
1. When executing `make downloadcheck`, this command will download mill files to created directory 'out', which makes git status dirty.
2. When the download process is interrupted, temporary `mill.*` files will not be cleaned automatically, thus we need to update the `make clean` rule.