### PR TITLE
Handle case of .mill-version with Windows line ends

### DIFF
--- a/millw
+++ b/millw
@@ -49,9 +49,9 @@ fi
 # If not already set, read .mill-version file
 if [ -z "${MILL_VERSION}" ] ; then
   if [ -f ".mill-version" ] ; then
-    MILL_VERSION="$(head -n 1 .mill-version 2> /dev/null)"
+    MILL_VERSION="$(tr '\r' '\n' < .mill-version | head -n 1 2> /dev/null)"
   elif [ -f ".config/mill-version" ] ; then
-    MILL_VERSION="$(head -n 1 .config/mill-version 2> /dev/null)"
+    MILL_VERSION="$(tr '\r' '\n' < .config/mill-version | head -n 1 2> /dev/null)"
   fi
 fi
 


### PR DESCRIPTION
This is a precaution for cases when the `.mill-version` file can contain a Windows line end `\r\n` instead of the typical Unix line end `\n`. Without this fix, in such situation the script breaks in a spectacular and surprising way.